### PR TITLE
Fix typo in favorites variable

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -55,7 +55,7 @@ const Profile = () => {
     }
   ];
 
-  const favoriteePlaces = [
+  const favoritePlaces = [
     {
       id: '4',
       name: 'Mont-Saint-Michel',
@@ -214,7 +214,7 @@ const Profile = () => {
 
           <TabsContent value="favorites" className="mt-6">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {favoriteePlaces.map((place) => (
+              {favoritePlaces.map((place) => (
                 <Card key={place.id} className="overflow-hidden hover:shadow-lg transition-shadow cursor-pointer">
                   <div className="relative">
                     <img 


### PR DESCRIPTION
## Summary
- correct `favoriteePlaces` typo in Profile component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684017dc2d64832d9dd896c6aa0a128a