### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Switch } from "@/components/ui/switch";
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const isDark = theme === "dark";
+
+  return (
+    <div className="flex items-center space-x-2">
+      <span className="text-sm text-gray-600">Clair</span>
+      <Switch checked={isDark} onCheckedChange={(val) => setTheme(val ? "dark" : "light")} />
+      <span className="text-sm text-gray-600">Sombre</span>
+    </div>
+  );
+};
+
+export default ThemeToggle;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { ThemeProvider } from 'next-themes';
 import App from './App.tsx';
 import './index.css';
 
@@ -13,6 +14,8 @@ if (!rootElement) {
 const root = createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import Navigation from '@/components/Navigation';
+import ThemeToggle from '@/components/ThemeToggle';
 
 const Settings = () => {
   return (
@@ -6,7 +7,11 @@ const Settings = () => {
       <Navigation />
       <div className="container mx-auto px-4 py-6 md:py-8 max-w-xl">
         <h1 className="text-2xl font-bold mb-4">Paramètres</h1>
-        <p>Cette page est un exemple de panneau de paramètres.</p>
+        <p className="mb-6">Cette page est un exemple de panneau de paramètres.</p>
+        <div className="py-4">
+          <h2 className="text-xl font-semibold mb-2">Thème</h2>
+          <ThemeToggle />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement dark mode provider
- add a theme toggle component
- expose the toggle in the settings page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68445bcb4e90832d953387671d6b7b13